### PR TITLE
Skip panama-specific User validation for the emergency user

### DIFF
--- a/lib/model_patches.rb
+++ b/lib/model_patches.rb
@@ -21,28 +21,30 @@ Rails.configuration.to_prepare do
         private
 
         def extra_fields_are_not_blank
-            if self.user_type.nil? or !["individual", "business"].include?(self.user_type)
-                errors.add(:user_type, _("User type must be 'business' or 'individual'"))
-            end
-            if self.phone_number.nil? or self.phone_number.strip.empty?
-                errors.add(:phone_number, _("Please enter a contact phone number"))
-            end
-            if self.is_individual?
-                if self.national_id_number.nil? or self.national_id_number.strip.empty?
-                    errors.add(:national_id_number, _("Please enter your national ID number"))
+            unless self.email == AlaveteliConfiguration::contact_email
+                if self.user_type.nil? or !["individual", "business"].include?(self.user_type)
+                    errors.add(:user_type, _("User type must be 'business' or 'individual'"))
                 end
-                if self.address.nil? or self.address.strip.empty?
-                    errors.add(:address, _("Please enter your address"))
+                if self.phone_number.nil? or self.phone_number.strip.empty?
+                    errors.add(:phone_number, _("Please enter a contact phone number"))
                 end
-            else
-                if self.company_name.nil? or self.company_name.strip.empty?
-                    errors.add(:company_name, _("Please enter your company name"))
-                end
-                if self.company_number.nil? or self.company_number.strip.empty?
-                    errors.add(:company_number, _("Please enter your company number"))
-                end
-                if self.incorporation_date.nil?
-                    errors.add(:incorporation_date, _("Please enter your company's incorporation date"))
+                if self.is_individual?
+                    if self.national_id_number.nil? or self.national_id_number.strip.empty?
+                        errors.add(:national_id_number, _("Please enter your national ID number"))
+                    end
+                    if self.address.nil? or self.address.strip.empty?
+                        errors.add(:address, _("Please enter your address"))
+                    end
+                else
+                    if self.company_name.nil? or self.company_name.strip.empty?
+                        errors.add(:company_name, _("Please enter your company name"))
+                    end
+                    if self.company_number.nil? or self.company_number.strip.empty?
+                        errors.add(:company_number, _("Please enter your company number"))
+                    end
+                    if self.incorporation_date.nil?
+                        errors.add(:incorporation_date, _("Please enter your company's incorporation date"))
+                    end
                 end
             end
         end


### PR DESCRIPTION
Should prevent the admin section from erroring out when logged in as the emergency user

Closes #46 

<!---
@huboard:{"order":49.0,"milestone_order":47,"custom_state":""}
-->
