### PR TITLE
Default new users to be individuals if no type is supplied

### DIFF
--- a/db/migrate/panamatheme_default_user_type_to_individual.rb
+++ b/db/migrate/panamatheme_default_user_type_to_individual.rb
@@ -1,0 +1,9 @@
+class PanamathemeDefaultUserTypeToIndividual < ActiveRecord::Migration
+  def self.up
+    change_column_default :users, :user_type, "individual"
+  end
+
+  def self.down
+    change_column_default :users, :user_type, nil
+  end
+end

--- a/post_install.rb
+++ b/post_install.rb
@@ -19,3 +19,9 @@ if !column_exists?(:users, :national_id_number)
     require File.expand_path '../db/migrate/panamatheme_add_extra_fields_to_user', __FILE__
     PanamathemeAddExtraFieldsToUser.up
 end
+
+# add the user_type default to User model
+if User.new.user_type.nil?
+    require File.expand_path '../db/migrate/panamatheme_default_user_type_to_individual', __FILE__
+    PanamathemeDefaultUserTypeToIndividual.up
+end

--- a/test/alavetelitheme_test.rb
+++ b/test/alavetelitheme_test.rb
@@ -60,12 +60,9 @@ class AlavetelithemeTest
             assert user.errors.messages.keys.include?(:incorporation_date)
         end
 
-        test "missing user_type creates an error" do
-            # may not be correct behaviour - should we default it to
-            # be an indivdual requestor instead?
-            user = User.new()
-            user.save
-            assert user.errors.messages.keys.include?(:user_type)
+        test "user_type should default to individual" do?
+            user = User.new
+            assert 'individual', user.user_type
         end
     end
 


### PR DESCRIPTION
In practice, this shouldn't happen within the app. However, it might happen when running scripts from the parent project. A tactic to avoid unexpected and potentially awkward to fix errors.

Ref: #44 

<!---
@huboard:{"order":60.5,"milestone_order":65,"custom_state":""}
-->
