### PR TITLE
Improved help page layout

### DIFF
--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -558,6 +558,7 @@ div.controller_help {
   dt {
     color: $heading-color;
     font-weight: 700;
+    font-size: 1.4em;
 
     @include respond-min( $main_menu-mobile_menu_cutoff ){
       font-size: 2em;
@@ -594,6 +595,44 @@ div.controller_help {
     margin-bottom: 0.2em;
   }
 }
+
+@include respond-min(36em){
+  .human_and_legal {
+    @include grid-row();
+
+    & > div:first-child {
+      @include grid-column(
+        $columns: 7,
+        $collapse: true
+      );
+
+      & + div {
+        @include grid-column(
+          $columns: 4,
+          $last-column: true,
+          $offset: 1,
+          $collapse: true
+        );
+        padding-left: 2em;
+      }
+    }
+  }
+}
+
+.human_and_legal > div:first-child + div {
+  color: lighten($body-font-color, 50%);
+  font-size: 0.9em;
+  line-height: 1.4em;
+
+  a {
+    color: mix($link-color, #fff, 80%);
+
+    &:hover, &:focus, &:active {
+      color: $link-color-hover;
+    }
+  }
+}
+
 
 /* Front page */
 /* Drop the extract indentation on small screens */

--- a/lib/views/help/requesting.html.erb
+++ b/lib/views/help/requesting.html.erb
@@ -31,22 +31,28 @@
 
 <dt id="which_authority">I’m not sure which authority to make my request to, how can I find out? <a href="#which_authority">#</a> </dt>
 
-<dd>
-<p>It can be hard to untangle government's complicated structured, and work out
-who knows the information that you want. Here are a few tips:
-<ul>
-<li>Browse or search <%= site_name %> looking for similar requests to yours.</li>
-<li>When you've found an authority you think might have the information, use
-the "home page" link on the right hand side of their page to check what they do
-on their website.</li>
-<li>Contact the authority by phone or email to ask if they hold the kind of
-information you're after.</li>
-<li>Don't worry excessively about getting the right authority. If you get it
-wrong, they ought to advise you who to make the request to instead.
-</li>
-<li>If you've got a thorny case, please <a href="/help/contact">contact us</a> for help.</li>
-</ul>
-
+<dd class="human_and_legal">
+  <div>
+    <p>It can be hard to untangle government's complicated structured, and work out
+    who knows the information that you want. Here are a few tips:
+    <ul>
+    <li>Browse or search <%= site_name %> looking for similar requests to yours.</li>
+    <li>When you've found an authority you think might have the information, use
+    the "home page" link on the right hand side of their page to check what they do
+    on their website.</li>
+    <li>Contact the authority by phone or email to ask if they hold the kind of
+    information you're after.</li>
+    <li>Don't worry excessively about getting the right authority. If you get it
+    wrong, they ought to advise you who to make the request to instead.
+    </li>
+    <li>If you've got a thorny case, please <a href="/help/contact">contact us</a> for help.</li>
+    </ul>
+  </div>
+  <div>
+    <p>This is an extract of legislation. Non o titulo occidental encyclopedia, uno medical linguas debitores se, post nomina e via. Qui ha duce studio tempore, vices complete del es, del extrahite supervivite interlinguistica ha.</p>
+    <p>Uso tamben association da. Le per technic germano svedese, pro altere gymnasios primarimente lo.</p>
+    <a href="#">Read the full law &raquo;</a>
+  </div>
 </dd>
 
 


### PR DESCRIPTION
Closes #63.

A bunch of improvements to the help page, including:
- Table of contents at the top of the "Requesting" help page.
- `.human_and_legal` markup and styling for side-by-side help layout.
- Prominent highlighting of the linked-to question when we link someone to a fragment of the page.
- More prominent link colour throughout the site.

![screen shot 2014-08-15 at 10 43 28](https://cloud.githubusercontent.com/assets/739624/3931931/6db3c800-2461-11e4-8c55-41a747ab3ac8.png)

<!---
@huboard:{"order":63.125,"milestone_order":67,"custom_state":""}
-->
