### PR TITLE
Add a form to generate a CSV of stats in the admin stats page

### DIFF
--- a/lib/config/custom-routes.rb
+++ b/lib/config/custom-routes.rb
@@ -11,4 +11,8 @@ Rails.application.routes.draw do
     end
 
     match '/help/transparency' => 'help#transparency', :as => :help_transparency
+
+    scope '/admin' do
+        match '/stats/monthly_transactions_csv' => 'admin_general#stats_monthly_transactions_csv', :as => :admin_stats_monthly_transactions_csv
+    end
 end

--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 # Add a callback - to be executed before each request in development,
 # and at startup in production - to patch existing app classes.
 # Doing so in init/environment.rb wouldn't work in development, since
@@ -173,6 +175,86 @@ Rails.configuration.to_prepare do
                     redirect_to user_url(@user)
                 end
             end
+        end
+    end
+
+    AdminGeneralController.class_eval do
+        def stats
+            # Overview counts of things
+            @public_body_count = PublicBody.count
+
+            @info_request_count = InfoRequest.count
+            @outgoing_message_count = OutgoingMessage.count
+            @incoming_message_count = IncomingMessage.count
+
+            @user_count = User.count
+            @track_thing_count = TrackThing.count
+
+            @comment_count = Comment.count
+            @request_by_state = InfoRequest.count(:group => 'described_state')
+            @tracks_by_type = TrackThing.count(:group => 'track_type')
+
+            # Add some additional values to the stats page for use in
+            # dropdowns
+            @first_request_datetime = InfoRequest.minimum(:created_at)
+        end
+
+        def stats_monthly_transactions_csv
+            start_year = params['date']['start_year'].to_i
+            start_month = params['date']['start_month'].to_i
+            end_year = params['date']['end_year'].to_i
+            end_month = params['date']['end_month'].to_i
+
+            month_starts = (Date.new(start_year, start_month)..Date.new(end_year, end_month)).select { |d| d.day == 1 }
+
+            headers = ['Period',
+                       'Requests sent',
+                       'Annotations added',
+                       'Track this request email signups',
+                       'Comments on own requests',
+                       'Follow up messages sent']
+            header_row = CSV.generate_line(headers)
+            header_row << "\n" unless RUBY_VERSION.to_f >= 1.9
+            csv = header_row
+
+            month_starts.each do |month_start|
+                month_end = month_start.end_of_month
+                period = "#{month_start}-#{month_end}"
+                date_conditions = ['created_at >= ?
+                                  AND created_at < ?',
+                                  month_start, month_end+1]
+                request_count = InfoRequest.count(:conditions => date_conditions)
+                comment_count = Comment.count(:conditions => date_conditions)
+                track_conditions = ['track_type = ?
+                                   AND track_medium = ?
+                                   AND created_at >= ?
+                                   AND created_at < ?',
+                                  'request_updates', 'email_daily', month_start, month_end+1]
+                email_request_track_count = TrackThing.count(:conditions => track_conditions)
+                comment_on_own_request_conditions = ['comments.user_id = info_requests.user_id
+                                                    AND comments.created_at >= ?
+                                                    AND comments.created_at < ?',
+                                                    month_start, month_end+1]
+                comment_on_own_request_count = Comment.count(:conditions => comment_on_own_request_conditions,
+                                                           :include => :info_request)
+
+                followup_conditions = ['message_type = ?
+                                       AND created_at >= ?
+                                       AND created_at < ?',
+                                      'followup', month_start, month_end+1]
+                follow_up_count = OutgoingMessage.count(:conditions => followup_conditions)
+                csv << CSV.generate_line([period,
+                                          request_count,
+                                          comment_count,
+                                          email_request_track_count,
+                                          comment_on_own_request_count,
+                                          follow_up_count])
+                csv << "\n" unless RUBY_VERSION.to_f >= 1.9
+
+            end
+
+            send_data csv, :filename => 'monthly-transaction-totals.csv',
+                                  :disposition => 'attachment'
         end
     end
 end

--- a/lib/views/admin_general/stats.html.erb
+++ b/lib/views/admin_general/stats.html.erb
@@ -1,0 +1,95 @@
+<% @title = "Statistics" %>
+<div class="hero-unit">
+  <h2><%=@public_body_count%> public authorities</h2>
+  <h2><%=@info_request_count%> requests, <%=@outgoing_message_count%> outgoing messages, <%=@incoming_message_count%> incoming messages</h2>
+  <h2><%=@user_count%> users, <%=@track_thing_count%> tracked things</h2>
+  <h2><%=@comment_count%> annotations</h2>
+</div>
+
+<div class="row">
+  <div class="span12">
+    <h1>Statistics</h1>
+    <h2>Chart of requests (excluding backpaged)</h2>
+    <img src="/foi-live-creation.png" alt="Chart of requests">
+  </div>
+</div>
+<div class="row">
+  <div class="span12">
+    <h2>State of requests (includes backpaged)</h2>
+    <div class="container">
+      <% for state, count in @request_by_state %>
+        <div class="row">
+          <div class="span1">
+            <span class="label label-info"><%=count%></span>
+          </div>
+          <div class="span4">
+            <%=state%>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="span12">
+    <h2>Chart of users</h2>
+    <img src="/foi-user-use.png" alt="Chart of users">
+  </div>
+</div>
+<div class="row">
+  <div class="span12">
+    <h2>Tracks by type</h2>
+    <div class="container">
+      <% for state, count in @tracks_by_type %>
+        <div class="row">
+          <div class="span1">
+            <span class="label label-info"><%=count%></span>
+          </div>
+          <div class="span4">
+            <%=state%>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>
+<div class="row">
+  <div class="span12">
+    <h2>Web analytics</h2>
+  </div>
+</div>
+<div class="row">
+  <div class="span12">
+    <h2>Downloads</h2>
+    <h3>Month-by-Month transaction totals</h3>
+    <p>A CSV file of the following totals:</p>
+    <ul>
+      <li>Requests</li>
+      <li>Annotations</li>
+      <li>Tracks</li>
+      <li>Comments by a requester on their own request</li>
+      <li>Follow ups</li>
+    </ul>
+    <p>You can specify a time range if you like, or use the defaults below, which cover all of the requests which have been made on this site.</p>
+    <%= form_tag url_for(admin_stats_monthly_transactions_csv_path), :method => 'GET' do %>
+      <div class="controls controls-row">
+        <%= label_tag :start_year, "Start year", :class => "span2" %>
+        <%= select_year(@first_request_datetime, {:field_name => :start_year, :start_year => @first_request_datetime.year, :end_year => Date.today.year}, {:class => "span2"}) %>
+
+        <%= label_tag :start_month, "Start month", :class => "span2" %>
+        <%= select_month(@first_request_datetime, {:field_name => :start_month}, {:class => "span2"}) %>
+      </div>
+
+      <div class="controls controls-row">
+        <%= label_tag :end_year, 'End year', {:class => "span2"} %>
+        <%= select_year(Date.today, {:field_name => :end_year, :start_year => @first_request_datetime.year, :end_year => Date.today.year}, {:class => "span2"}) %>
+
+        <%= label_tag :end_month, 'End month', {:class => "span2"} %>
+        <%= select_month(Date.today, {:field_name => :end_month}, {:class => "span2"}) %>
+      </div>
+      <div class="controls controls-row">
+        <button type='submit' class="btn"><i class="icon-download"></i> Download</button>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/spec/controllers/controller_patches_spec.rb
+++ b/spec/controllers/controller_patches_spec.rb
@@ -38,3 +38,32 @@ describe UserController do
     expect(response.status).to eq(200)
   end
 end
+
+describe AdminGeneralController, "when the stats action is patched" do
+  before(:each) do
+    controller.stub(:authenticated?).and_return(true)
+  end
+
+  it "should add the datestamp of the first request into the context" do
+    get :stats
+    expect(assigns(:first_request_datetime)).to eq InfoRequest.minimum(:created_at)
+  end
+end
+
+describe AdminGeneralController, "when generating a stats csv" do
+  before(:each) do
+    controller.stub(:authenticated?).and_return(true)
+  end
+
+  it "should generate the correct csv" do
+    response = get :stats_monthly_transactions_csv, :date => {:start_year => "2006",
+                                                   :start_month => "1",
+                                                   :end_year => "2006",
+                                                   :end_month => "1"}
+    expected_csv = <<EOD
+Period,Requests sent,Annotations added,Track this request email signups,Comments on own requests,Follow up messages sent
+2006-01-01-2006-01-31,2,0,0,0,0
+EOD
+    expect(response.body).to eq(expected_csv)
+  end
+end


### PR DESCRIPTION
This creates a new section on the admin page which houses a form for
selecting a date range and a button to generate a CSV download of
stats. The stats calculations themselves are copied from an existing
rake task and then put into a new controller action.

Closes #22
Closes #21

<!---
@huboard:{"order":73.16796875,"milestone_order":82,"custom_state":""}
-->
