### PR TITLE
Override user_params whitelisting for Panama

### DIFF
--- a/lib/controller_patches.rb
+++ b/lib/controller_patches.rb
@@ -180,6 +180,14 @@ Rails.configuration.to_prepare do
                 end
             end
         end
+
+        def user_params(key = :user)
+            # Override user_params whitelist to allow our additional fields
+            params[key].slice(:name, :email, :password, :password_confirmation,
+                              :phone_number, :user_type, :address,
+                              :national_id_number, :company_name,
+                              :company_number, :incorporation_date)
+        end
     end
 
     AdminGeneralController.class_eval do

--- a/spec/controllers/controller_patches_spec.rb
+++ b/spec/controllers/controller_patches_spec.rb
@@ -37,6 +37,26 @@ describe UserController do
     get :signchangecompanyincdate
     expect(response.status).to eq(200)
   end
+
+  it "should override user_params" do
+    params = {
+      :user => {
+        :name => 'test',
+        :email => 'test@example.com',
+        :password => 'password',
+        :password_confirmation => 'password',
+        :phone_number => '123456789',
+        :user_type => 'individual',
+        :address => '1, street, town, country, POSTCODE',
+        :national_id_number => 'aab123464678',
+        :spurious_parameter => 'spurious'
+      }
+    }
+    expected_params = params[:user].clone
+    expected_params.delete(:spurious_parameter)
+    controller.params = params
+    expect(controller.user_params).to eq expected_params
+  end
 end
 
 describe AdminGeneralController, "when the stats action is patched" do

--- a/spec/integration/signing_up_spec.rb
+++ b/spec/integration/signing_up_spec.rb
@@ -1,0 +1,52 @@
+# If defined, ALAVETELI_TEST_THEME will be loaded in config/initializers/theme_loader
+ALAVETELI_TEST_THEME = 'panama-theme'
+require File.expand_path(File.join(File.dirname(__FILE__),'..','..','..','..','..','spec','spec_helper'))
+
+describe "Signing up" do
+  it "Should allow me to sign up as an individual" do
+    visit '/profile/sign_in'
+
+    fill_in "user_signup[email]", :with => "test@example.com"
+    fill_in "user_signup[name]", :with => "Test User"
+    fill_in "user_signup[phone_number]", :with => "123456789"
+    choose "Individual"
+    fill_in "user_signup[address]", :with => "1, street, town, country, POSTCODE"
+    fill_in "user_signup[national_id_number]", :with => "aabc123456789"
+    fill_in "user_signup[password]", :with => 'password'
+    fill_in "user_signup[password_confirmation]", :with => 'password'
+
+    click_button "Sign up"
+
+    assert_contain("Now check your email")
+
+    expect(User.where(:email => "test@example.com",
+                      :user_type => 'individual',
+                      :phone_number => '123456789',
+                      :national_id_number => 'aabc123456789',
+                      :address => '1, street, town, country, POSTCODE')).to exist
+  end
+
+  it "Should allow me to sign up as a business" do
+    visit '/profile/sign_in'
+
+    fill_in "user_signup[email]", :with => "test@example.com"
+    fill_in "user_signup[name]", :with => "Test User"
+    fill_in "user_signup[phone_number]", :with => "123456789"
+    choose "Legal person"
+    fill_in "user_signup[company_name]", :with => "Company"
+    fill_in "user_signup[company_number]", :with => "aabc123456789"
+    fill_in "user_signup[incorporation_date]", :with => '01/01/2000'
+    fill_in "user_signup[password]", :with => 'password'
+    fill_in "user_signup[password_confirmation]", :with => 'password'
+
+    click_button "Sign up"
+
+    assert_contain("Now check your email")
+
+    expect(User.where(:email => "test@example.com",
+                      :user_type => 'business',
+                      :company_name => 'Company',
+                      :company_number => 'aabc123456789',
+                      :incorporation_date => '2000-01-01')).to exist
+  end
+end


### PR DESCRIPTION
Alaveteli has added a method to the users controllers to whitelist the
params that can be altered when signing up a new user. This stops our
custom user fields from being saved and so breaks the signup process.

This commit overrides the whitelisting method so that we can pass
these fields again.

Closes #90
