### PR TITLE
Improve layout of help pages

### DIFF
--- a/assets/javascripts/legal-summaries.js
+++ b/assets/javascripts/legal-summaries.js
@@ -1,15 +1,14 @@
 (function($) {
 
-  var summarise = function(){
+  var summarise = function summarise(){
     var $div = $(this);
     var $firstP = $('p:first-of-type', $div);
     var $extraElements = $firstP.nextAll();
 
     if($extraElements.length > 0){
 
-      if($('html').attr('lang') == 'es'){
-        var readMore = '(Ver mas)';
-      } else {
+      var readMore = '(Ver mas)';
+      if($('html').attr('lang') != 'es'){
         var readMore = '(Read more)';
       }
 

--- a/assets/javascripts/legal-summaries.js
+++ b/assets/javascripts/legal-summaries.js
@@ -1,0 +1,29 @@
+(function($) {
+
+  var summarise = function(){
+    var $div = $(this);
+    var $firstP = $('p:first-of-type', $div);
+    var $extraElements = $firstP.nextAll();
+
+    if($extraElements.length > 0){
+
+      if($('html').attr('lang') == 'es'){
+        var readMore = '(Ver mas)';
+      } else {
+        var readMore = '(Read more)';
+      }
+
+      var $moreLink = $('<a>').on('click', function(){
+        $(this).parent().nextAll().show();
+        $(this).remove();
+      }).text(readMore).addClass('read_more');
+
+      $firstP.append(' ').append($moreLink).nextAll().hide();
+
+    }
+  }
+
+  $(function(){
+    $('.human_and_legal > div + div').each(summarise);
+  })
+})($);

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -745,9 +745,21 @@ div.controller_help {
   margin-top: 1em;
 
   h3 {
-    margin: 0 0 0.6em 0;
+    margin: 0;
     font-size: 1.2em;
     color: inherit;
+  }
+
+  .full_law {
+    display: block;
+    font-size: 0.9em;
+    font-weight: bold;
+    margin: 0.6em 0;
+  }
+
+  // In the unlikely event that there isn't a full_law link
+  h3 + p {
+    margin-top: 0.8em;
   }
 
   a {

--- a/assets/stylesheets/responsive/custom.scss
+++ b/assets/stylesheets/responsive/custom.scss
@@ -690,12 +690,6 @@ div.controller_help {
     margin-top: 10px;
   }
 
-  #left_column_flip {
-    p, ol li, dd div {
-      text-align: justify;
-    }
-  }
-
   dt, h1 {
     &:hover > a {
       color: $link-color-hover;
@@ -743,6 +737,28 @@ div.controller_help {
   }
 }
 
+.human_and_legal > div:first-child + div {
+  color: lighten($body-font-color, 30%);
+  font-size: 0.9em;
+  line-height: 1.4em;
+  text-align: left;
+  margin-top: 1em;
+
+  h3 {
+    margin: 0 0 0.6em 0;
+    font-size: 1.2em;
+    color: inherit;
+  }
+
+  a {
+    color: mix($link-color, #fff, 80%);
+
+    &:hover, &:focus, &:active {
+      color: $link-color-hover;
+    }
+  }
+}
+
 @include respond-min(36em){
   .human_and_legal {
     @include grid-row();
@@ -760,27 +776,9 @@ div.controller_help {
           $offset: 1,
           $collapse: true
         );
-        padding-left: 2em;
+        margin-top: 0;
       }
     }
-  }
-}
-
-.human_and_legal > div:first-child + div {
-  color: lighten($body-font-color, 30%);
-  font-size: 0.9em;
-  line-height: 1.4em;
-
-  a {
-    color: mix($link-color, #fff, 80%);
-
-    &:hover, &:focus, &:active {
-      color: $link-color-hover;
-    }
-  }
-
-  p {
-    text-align: justify;
   }
 }
 

--- a/lib/views/help/alaveteli.en.html.erb
+++ b/lib/views/help/alaveteli.en.html.erb
@@ -26,8 +26,10 @@
       </div>
       <div>
         <h3>CONSTITUTION OF THE REPUBLIC OF PANAMA</h3>
-        <p><strong>Article 43.</strong> Everyone has the right to request information from public access or public interest that rests in databases or records held by public servants or private individuals who provide public services, as long as such access has not been limited by available written and mandated by the Act and to demand their fair and correct treatment.<br/>
-        <a href="http://www.antai.gob.pa/publicaciones/constituciondepanama.pdf">Read the full law &raquo;</a>
+
+        <a class="full_law" href="http://www.antai.gob.pa/publicaciones/constituciondepanama.pdf">Read the full law &raquo;</a>
+
+        <p><strong>Article 43.</strong> Everyone has the right to request information from public access or public interest that rests in databases or records held by public servants or private individuals who provide public services, as long as such access has not been limited by available written and mandated by the Act and to demand their fair and correct treatment.</p>
       </div>
     </dd>
 
@@ -39,8 +41,10 @@
       </div>
       <div>
         <h3>Article 7 of Law 6 January 22, 2002</h3>
-        <p><strong>Article 7.</strong> The public servant receiving shall have thirty calendar days from the date of submission of the request, to answer in writing, and, if it does not have the documents or records requested, so you know. If the officer has knowledge that another institution has or may have in their possession such documents or similar documents will be obliged to indicate it to the requestor.<br/>
-        <a href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Read the full law &raquo;</a></p>
+
+        <a class="full_law" href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Read the full law &raquo;</a>
+
+        <p><strong>Article 7.</strong> The public servant receiving shall have thirty calendar days from the date of submission of the request, to answer in writing, and, if it does not have the documents or records requested, so you know. If the officer has knowledge that another institution has or may have in their possession such documents or similar documents will be obliged to indicate it to the requestor.</p>
       </div>
     </dd>
 
@@ -69,13 +73,16 @@
       </div>
       <div>
         <h3>Article 17 of Law 6 of January 22, 2002</h3>
-        <p><strong>Article 17.</strong> Everyone shall be entitled to bring an action for Habeas Data, in order to guarantee the right of access to information under this Law, if the holder or public servant responsible of the record, file or database in which the information or personal data claimed was not provided as requested or if the required information has been done insufficient or inaccurately.<br/>
-        <a href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Read the full law &raquo;</a></p>
+
+        <a class="full_law" href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Read the full law &raquo;</a>
+
+        <p><strong>Article 17.</strong> Everyone shall be entitled to bring an action for Habeas Data, in order to guarantee the right of access to information under this Law, if the holder or public servant responsible of the record, file or database in which the information or personal data claimed was not provided as requested or if the required information has been done insufficient or inaccurately.</p>
 
         <h3>Article 36 of Law 33 of April 25, 2013</h3>
 
-        <p><strong>Article 36.</strong> Any person may resort to the authority for non-compliance of terms and procedures established for the effective exercise of the right of petition and right of access to public information in power of the state, provided by law, within thirty days from the date after proving the non compliance. <br/>
-        <a href="http://www.antai.gob.pa/publicaciones/ley33-25-abril-2013.pdf">Read the full law &raquo;</a></p>
+        <a class="full_law" href="http://www.antai.gob.pa/publicaciones/ley33-25-abril-2013.pdf">Read the full law &raquo;</a>
+
+        <p><strong>Article 36.</strong> Any person may resort to the authority for non-compliance of terms and procedures established for the effective exercise of the right of petition and right of access to public information in power of the state, provided by law, within thirty days from the date after proving the non compliance.</p>
       </div>
     </dd>
 
@@ -87,11 +94,15 @@
       </div>
       <div>
         <h3>Article 2. of Law 33 of April 25, 2013</h3>
-        <p><strong>Article 2.</strong> The authority shall ensure compliance with the rights enshrined in the constitution of the republic of panama on the issue of constitutional law regarding requests and access to information, as well as rights under international conventions, agreements, treaties, international and national programs in preventing corruption and the insertion and implementation of new prevention policies in public administration at government level on their own or by national or international proposals.<br/>
-        <a href="http://www.antai.gob.pa/publicaciones/ley33-25-abril-2013.pdf">Read the full law &raquo;</a></p>
+
+        <a class="full_law" href="http://www.antai.gob.pa/publicaciones/ley33-25-abril-2013.pdf">Read the full law &raquo;</a>
+
+        <p><strong>Article 2.</strong> The authority shall ensure compliance with the rights enshrined in the constitution of the republic of panama on the issue of constitutional law regarding requests and access to information, as well as rights under international conventions, agreements, treaties, international and national programs in preventing corruption and the insertion and implementation of new prevention policies in public administration at government level on their own or by national or international proposals.</p>
       </div>
     </dd>
   </dl>
 
   <div id="hash_link_padding"></div>
 </div>
+
+<%= javascript_include_tag "legal-summaries" %>

--- a/lib/views/help/alaveteli.es.html.erb
+++ b/lib/views/help/alaveteli.es.html.erb
@@ -26,7 +26,10 @@
       </div>
       <div>
         <h3>CONSTITUCIÓN POLÍTICA DE LA REPÚBLICA DE PANAMÁ</h3>
-        <p><strong>Articulo 43.</strong> Toda persona tiene derecho a solicitar información de acceso público o de interés colectivo que repose en bases de datos o registros a cargo de servidores públicos o de personas privadas que presten servicios públicos, siempre que ese acceso no haya sido limitado por disposición escrita y por mandato de la Ley, así como para exigir su tratamiento leal y rectificación.<br/><a href="http://www.antai.gob.pa/publicaciones/constituciondepanama.pdf">Lea la ley completa &raquo;</a></p>
+
+        <a class="full_law" href="http://www.antai.gob.pa/publicaciones/constituciondepanama.pdf">Lea la ley completa &raquo;</a>
+
+        <p><strong>Articulo 43.</strong> Toda persona tiene derecho a solicitar información de acceso público o de interés colectivo que repose en bases de datos o registros a cargo de servidores públicos o de personas privadas que presten servicios públicos, siempre que ese acceso no haya sido limitado por disposición escrita y por mandato de la Ley, así como para exigir su tratamiento leal y rectificación.</p>
     </dd>
 
     <dt id="how_work">¿Cómo funciona? <a href="#how_work">#</a> </dt>
@@ -37,7 +40,10 @@
       </div>
       <div>
         <h3>Ley 6 del 22 de enero del 2002</h3>
-        <p>Artículo 7. El funcionario receptor tendrá treinta días calendario a partir de la fecha de la presentación de la solicitud, para contestarla por escrito, y, en caso de que ésta no posea el o los documentos o registros solicitados, así lo informará.<br/><a href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Lea la ley completa &raquo;</a></p>
+
+        <a class="full_law" href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Lea la ley completa &raquo;</a>
+
+        <p>Artículo 7. El funcionario receptor tendrá treinta días calendario a partir de la fecha de la presentación de la solicitud, para contestarla por escrito, y, en caso de que ésta no posea el o los documentos o registros solicitados, así lo informará.</p>
       </div>
     </dd>
 
@@ -65,11 +71,15 @@
       <div>
         <h3>Artículo 17 de la Ley 6 de 22 de enero de 2002</h3>
 
-        <p><strong>Artículo 17.</strong> Toda persona estará legitimada para promover acción de Hábeas Data, con miras a garantizar el derecho de acceso a la información previsto en esta Ley, cuando el funcionario público titular o responsable del registro, archivo o banco de datos en el que se encuentra la información o dato personal reclamado, no le haya suministrado lo solicitado o si suministrado lo requerido se haya hecho de manera insuficiente o en forma inexacta.<br/><a href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Lea la ley completa &raquo;</a></p>
+        <a class="full_law" href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Lea la ley completa &raquo;</a>
+
+        <p><strong>Artículo 17.</strong> Toda persona estará legitimada para promover acción de Hábeas Data, con miras a garantizar el derecho de acceso a la información previsto en esta Ley, cuando el funcionario público titular o responsable del registro, archivo o banco de datos en el que se encuentra la información o dato personal reclamado, no le haya suministrado lo solicitado o si suministrado lo requerido se haya hecho de manera insuficiente o en forma inexacta.</p>
 
         <h3>Artículo 36 de la Ley 33 del 25 de abril de 2013</h3>
 
-        <p><strong>Artículo 36.</strong> Toda persona puede recurrir ante la Autoridad por el incumplimiento de los procedimientos y términos establecidos para el efectivo ejercicio del derecho de petición y derecho de acceso a la información pública en poder del Estado, previstos en las disposiciones legales, dentro de los treinta días a partir de la fecha en que se demuestre se incurrió en el incumplimiento.<br/><a href="http://www.antai.gob.pa/publicaciones/ley33-25-abril-2013.pdf">Lea la ley completa &raquo;</a></p>
+        <a class="full_law" href="http://www.antai.gob.pa/publicaciones/ley33-25-abril-2013.pdf">Lea la ley completa &raquo;</a>
+
+        <p><strong>Artículo 36.</strong> Toda persona puede recurrir ante la Autoridad por el incumplimiento de los procedimientos y términos establecidos para el efectivo ejercicio del derecho de petición y derecho de acceso a la información pública en poder del Estado, previstos en las disposiciones legales, dentro de los treinta días a partir de la fecha en que se demuestre se incurrió en el incumplimiento.</p>
       </div>
     </dd>
 
@@ -81,9 +91,14 @@
       <div>
         <h3>Artículo 2 de la Ley 33 del 25 de abril de 2013</h3>
 
-        <p>La Autoridad velará por el cumplimiento de los derechos consagrados en la Constitución Política de la República de Panamá en el tema de Derecho Constitucional de petición y de acceso a la información, así como por los derechos previstos en los convenios, acuerdos, tratados, programas internacionales y nacionales en materia de prevención contra la corrupción y por la inserción e implementación de las nuevas políticas de prevención en la gestión pública a nivel gubernamental por iniciativa propia o por propuestas nacionales o internacionales.<a href="http://www.antai.gob.pa/publicaciones/ley33-25-abril-2013.pdf">Lea la ley completa &raquo;</a></p>
+        <a class="full_law" href="http://www.antai.gob.pa/publicaciones/ley33-25-abril-2013.pdf">Lea la ley completa &raquo;</a>
+
+        <p>La Autoridad velará por el cumplimiento de los derechos consagrados en la Constitución Política de la República de Panamá en el tema de Derecho Constitucional de petición y de acceso a la información, así como por los derechos previstos en los convenios, acuerdos, tratados, programas internacionales y nacionales en materia de prevención contra la corrupción y por la inserción e implementación de las nuevas políticas de prevención en la gestión pública a nivel gubernamental por iniciativa propia o por propuestas nacionales o internacionales.</p>
       </div>
     </dd>
   </dl>
+
   <div id="hash_link_padding"></div>
 </div>
+
+<%= javascript_include_tag "legal-summaries" %>

--- a/lib/views/help/faq.en.html.erb
+++ b/lib/views/help/faq.en.html.erb
@@ -24,8 +24,9 @@
       <div>
         <h3>Article 2 Law 6 of January 22, 2002</h3>
 
-        <p>Everyone has the right to request, without justification or motivation, the public information in the possession or knowledge of the institutions indicated in this Law.<br/>
-        <a href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Read the full law &raquo;</a></p>
+        <a class="full_law" href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Read the full law &raquo;</a>
+
+        <p>Everyone has the right to request, without justification or motivation, the public information in the possession or knowledge of the institutions indicated in this Law.</p>
       </div>
     </dd>
 
@@ -35,6 +36,8 @@
       <div>You can request any information that is not classified as restricted or confidential access. <a href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Articles 13 to 15 Law 6 of January 22, 2002.</a></div>
       <div>
         <h3>Articles 13-16, Law 6 of January 22, 2002</h3>
+
+        <a class="full_law" href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Read the full law &raquo;</a>
 
         <p><strong>Article 13.</strong> The information defined by this Law as confidential shall not be disclosed, under any circumstances, by agents of the State.</p>
         <p>In the event that confidential information is part of judicial process, the competent authorities shall take the required provisions for such information to be kept confidential and access to it only to the respective parties involved in the judicial process.</p>
@@ -62,8 +65,7 @@
 
         <p><strong>Article 15.</strong> The administrative confidential records, including those relating to bank accounts, information on investigations or reports of suspicious transactions related to money laundering, underage; judicial, arbitral and Public Ministry shall be governed by the rules of access and information contained in the Judicial Code, the banking legislation and regulations applicable to the prevention and combating of money laundering</p>
 
-        <p><strong>Article 16.</strong> State institutions that deny the granting of information considered confidential or restricted must do so through a motivated decision, setting out the grounds on which the denial is based and that are supported by this Law.<br/>
-        <a href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Read the full law &raquo;</a></p>
+        <p><strong>Article 16.</strong> State institutions that deny the granting of information considered confidential or restricted must do so through a motivated decision, setting out the grounds on which the denial is based and that are supported by this Law.</p>
       </div>
     </dd>
 
@@ -76,8 +78,9 @@
       <div>
         <h3>Law 6 of January 22, 2002</h3>
 
-        <p><strong>Article 7.</strong> The public servant receiving shall have thirty calendar days from the date of submission of the request, to answer in writing, and, if it does not havee documents or records requested, so you know. If the officer has knowledge that another institution has or may have in their possession such documents or similar documents will be obliged to indicate it to the requestor. In case of a complicated or complex application, the official shall inform in writing, within thirty calendar days noted above, the need to extend the term to gather the required information. In any case, the term will exceed thirty calendar days.<br/>
-        <a href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Read the full law &raquo;</a></p>
+        <a class="full_law" href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Read the full law &raquo;</a>
+
+        <p><strong>Article 7.</strong> The public servant receiving shall have thirty calendar days from the date of submission of the request, to answer in writing, and, if it does not havee documents or records requested, so you know. If the officer has knowledge that another institution has or may have in their possession such documents or similar documents will be obliged to indicate it to the requestor. In case of a complicated or complex application, the official shall inform in writing, within thirty calendar days noted above, the need to extend the term to gather the required information. In any case, the term will exceed thirty calendar days.</p>
       </div>
     </dd>
 
@@ -96,6 +99,6 @@
   </dl>
 
   <div id="hash_link_padding"></div>
-
-
 </div>
+
+<%= javascript_include_tag "legal-summaries" %>

--- a/lib/views/help/faq.es.html.erb
+++ b/lib/views/help/faq.es.html.erb
@@ -25,7 +25,9 @@
       <div>
         <h3>Artículo 2 de la Ley 6 de 22 de enero 2002</h3>
 
-        <p>Toda persona tiene derecho a solicitar, sin necesidad de sustentar justificación o motivación alguna, la información de acceso público en poder o en conocimiento de las instituciones indicadas en la presente Ley.<br/><a href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Lea la ley completa &raquo;</a></p>
+        <a class="full_law"href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Lea la ley completa &raquo;</a>
+
+        <p>Toda persona tiene derecho a solicitar, sin necesidad de sustentar justificación o motivación alguna, la información de acceso público en poder o en conocimiento de las instituciones indicadas en la presente Ley.</p>
       </div>
     </dd>
 
@@ -36,6 +38,8 @@
       </div>
       <div>
         <h3>Ley 6 del 22 de enero del 2002 Artículo 13, 14, 15, 16</h3>
+
+        <a class="full_law" href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Lea la ley completa &raquo;</a>
 
         <p><atrong>Artículo 13.</atrong> La información definida por la presente Ley como confidencial no podrá ser divulgada, bajo ninguna circunstancia, por agentes del Estado.</p>
 
@@ -64,7 +68,7 @@
 
         <p><strong>Artículo 15.</strong> Los expedientes administrativos de carácter reservado, tales como los que tienen relación con cuentas bancarias, información sobre investigaciones o reportes de operaciones sospechosas relacionadas con el blanqueo de capitales, menores de edad; los judiciales, arbitrales y del Ministerio Público, se regirán por las normas de acceso y de información contenidas en el Código Judicial, la legislación bancaria y normas aplicables a la prevención y el combate del blanqueo de capitales.</p>
 
-        <p><strong>Artículo 16.</strong> Las instituciones del Estado que nieguen el otorgamiento de una información por considerarla de carácter confidencial o de acceso restringido, deberán hacerlo a través de resolución motivada, estableciendo las razones en que se fundamentan la negación y que se sustenten en esta Ley.<br/><a href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Lea la ley completa &raquo;</a></p>
+        <p><strong>Artículo 16.</strong> Las instituciones del Estado que nieguen el otorgamiento de una información por considerarla de carácter confidencial o de acceso restringido, deberán hacerlo a través de resolución motivada, estableciendo las razones en que se fundamentan la negación y que se sustenten en esta Ley.</p>
       </div>
     </dd>
 
@@ -76,7 +80,9 @@
       <div>
         <h3>Artículo 7 de la Ley 6 de 22 de enero de 2002.</h3>
 
-        <p><strong>Artículo 7.</strong> El funcionario receptor tendrá treinta días calendario a partir de la fecha de la presentación de la solicitud, para contestarla por escrito, y, en caso de que ésta no posea el o los documentos o registros solicitados, así lo informará. Si el funcionario tiene conocimiento que otra institución tiene o pueda tener en su poder dichos documentos o documentos similares, estará obligado a indicárselo al solicitante. De tratarse de una solicitud compleja o extensa, el funcionario informará por escrito, dentro de los treinta días calendario antes señalados, la necesidad de extender el término para recopilar la información solicitada. En ningún caso, dicho término podrá exceder de treinta días calendarios adicionales.<br/><a href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Lea la ley completa &raquo;</a></p>
+        <a class="full_law" href="http://www.antai.gob.pa/publicaciones/Ley-6-de-22-enero-2002.pdf">Lea la ley completa &raquo;</a>
+
+        <p><strong>Artículo 7.</strong> El funcionario receptor tendrá treinta días calendario a partir de la fecha de la presentación de la solicitud, para contestarla por escrito, y, en caso de que ésta no posea el o los documentos o registros solicitados, así lo informará. Si el funcionario tiene conocimiento que otra institución tiene o pueda tener en su poder dichos documentos o documentos similares, estará obligado a indicárselo al solicitante. De tratarse de una solicitud compleja o extensa, el funcionario informará por escrito, dentro de los treinta días calendario antes señalados, la necesidad de extender el término para recopilar la información solicitada. En ningún caso, dicho término podrá exceder de treinta días calendarios adicionales.</p>
       </div>
     </dd>
 
@@ -92,6 +98,6 @@
   </dl>
 
   <div id="hash_link_padding"></div>
-
-
 </div>
+
+<%= javascript_include_tag "legal-summaries" %>


### PR DESCRIPTION
Fixes #101.

* Removes `text-align: justify`
* Reduces font-size and margins for legal section headings
* Hides all but the first paragraph of legal text, behind a "show more" link

![screen shot 2015-01-19 at 14 57 59](https://cloud.githubusercontent.com/assets/739624/5802307/9611ce7c-9feb-11e4-9c27-cbd8827bf02c.png)


